### PR TITLE
Addition of code to process AB, BC, NL, YT time series data

### DIFF
--- a/R/ab.R
+++ b/R/ab.R
@@ -299,6 +299,68 @@ process_ab <- function(uuid, val, fmt, ds,
         e_val()
       )
     },
+    "3ced816d-8524-4875-bd69-61fb5603b596" = {
+      switch(
+        val,
+        "cases" = {
+          switch(
+            fmt,
+            "prov_ts" = {
+              ds %>%
+                dplyr::select(Date.reported.to.Alberta.Health, Active.cases) %>%
+                dplyr::mutate(
+                  value = readr::parse_number(as.character(.$Active.cases))
+                ) %>%
+                helper_ts(loc = "prov", val, prov, convert_to_cum = TRUE)
+            },
+            e_fmt()
+          )
+        },
+        "mortality" = {
+          switch(
+            fmt,
+            "prov_ts" = {
+              ds %>%
+                dplyr::select(Date.reported.to.Alberta.Health, Number.of.deaths) %>%
+                dplyr::mutate(
+                  value = readr::parse_number(as.character(.$Number.of.deaths))
+                ) %>%
+                helper_ts(loc = "prov", val, prov, convert_to_cum = TRUE)
+            },
+            e_fmt()
+          )
+        },
+        "hospitalizations" = {
+          switch(
+            fmt,
+            "prov_ts" = {
+              ds %>%
+                dplyr::select(Date.reported.to.Alberta.Health, Currently.hospitalized) %>%
+                dplyr::mutate(
+                  value = readr::parse_number(as.character(.$Currently.hospitalized))
+                ) %>%
+                helper_ts(loc = "prov", val, prov, convert_to_cum = TRUE)
+            },
+            e_fmt()
+          )
+        },
+        "icu" = {
+          switch(
+            fmt,
+            "prov_ts" = {
+              ds %>%
+                dplyr::select(Date.reported.to.Alberta.Health, Currently.in.ICU) %>%
+                dplyr::mutate(
+                  value = readr::parse_number(as.character(.$Currently.in.ICU))
+                ) %>%
+                helper_ts(loc = "prov", val, prov, convert_to_cum = TRUE)
+            },
+            e_fmt()
+          )
+        },
+        e_val()
+      )
+    },
     e_uuid()
   )
 }

--- a/R/bc.R
+++ b/R/bc.R
@@ -222,6 +222,33 @@ process_bc <- function(uuid, val, fmt, ds,
         e_val()
       )
     },
+    "4f9dc8b7-7b42-450e-a741-a0f6a621d2af" = {
+      switch(
+        val,
+        "cases" = {
+          switch(
+            fmt,
+            "hr_ts" = {
+              ds$features$attributes %>%
+                dplyr::filter(.data$HSDA == "All" & .data$HA != "All") %>%
+                dplyr::mutate(Date = lubridate::date(
+                  lubridate::with_tz(as.POSIXct(.data$Date / 1000, origin = "1970-01-01"),
+                                     tz = "UTC")),) %>%
+                dplyr::select( .data$Date, .data$HA, .data$Cases_Reported) %>%
+                dplyr::arrange(.data$HA, .data$Date) %>%
+                dplyr::rename(
+                  sub_region_1 = .data$HA,
+                  date = .data$Date,
+                  value = .data$Cases_Reported
+                ) %>%
+                helper_ts(loc = "hr", val, prov, convert_to_cum = TRUE)
+            },
+            e_fmt()
+          )
+        },
+        e_val()
+      )
+    },
     e_uuid()
   )
 }

--- a/R/nl.R
+++ b/R/nl.R
@@ -248,6 +248,75 @@ process_nl <- function(uuid, val, fmt, ds,
         e_val()
       )
     },
+    "13a35524-89bf-46a2-afc5-d88ef81bfa82" = {
+      switch(
+        val,
+        "cases" = {
+          switch(
+            fmt,
+            "prov_ts" = {
+              ds$features$attributes %>%
+                dplyr::mutate(
+                  date_of_update = lubridate::date(
+                    lubridate::with_tz(as.POSIXct(.data$date_of_update / 1000, origin = "1970-01-01"), tz = "UTC"))
+                ) %>%
+                dplyr::select(.data$date_of_update, .data$joinfield, .data$active_cases) %>%
+                dplyr::arrange(.data$date_of_update, .data$active_cases) %>%
+                dplyr::rename(
+                  sub_region_1 = .data$joinfield,
+                  date = .data$date_of_update,
+                  value = .data$active_cases
+                ) %>%
+                helper_ts(loc = "prov", val, prov, convert_to_cum = TRUE)
+            },
+            e_fmt()
+          )
+        },
+        "mortality" = {
+          switch(
+            fmt,
+            "prov_ts" = {
+              ds$features$attributes %>%
+                dplyr::mutate(
+                  date_of_update = lubridate::date(
+                    lubridate::with_tz(as.POSIXct(.data$date_of_update / 1000, origin = "1970-01-01"), tz = "UTC"))
+                ) %>%
+                dplyr::select(.data$date_of_update, .data$joinfield, .data$total_deaths) %>%
+                dplyr::arrange(.data$date_of_update, .data$total_deaths) %>%
+                dplyr::rename(
+                  sub_region_1 = .data$joinfield,
+                  date = .data$date_of_update,
+                  value = .data$total_deaths
+                ) %>%
+                helper_ts(loc = "prov", val, prov, convert_to_cum = FALSE)
+            },
+            e_fmt()
+          )
+        },
+        "hospitalizations" = {
+          switch(
+            fmt,
+            "prov_ts" = {
+              ds$features$attributes %>%
+                dplyr::mutate(
+                  date_of_update = lubridate::date(
+                    lubridate::with_tz(as.POSIXct(.data$date_of_update / 1000, origin = "1970-01-01"), tz = "UTC"))
+                ) %>%
+                dplyr::select(.data$date_of_update, .data$joinfield, .data$currently_hospitalized) %>%
+                dplyr::arrange(.data$date_of_update, .data$currently_hospitalized) %>%
+                dplyr::rename(
+                  sub_region_1 = .data$joinfield,
+                  date = .data$date_of_update,
+                  value = .data$currently_hospitalized
+                ) %>%
+                helper_ts(loc = "prov", val, prov, convert_to_cum = FALSE)
+            },
+            e_fmt()
+          )
+        },
+        e_val()
+      )
+    },
     e_uuid()
   )
 }

--- a/R/yt.R
+++ b/R/yt.R
@@ -346,6 +346,50 @@ process_yt <- function(uuid, val, fmt, ds,
         e_val()
       )
     },
+    "7698e84c-f43f-4a83-828a-1d26e21467b9" = {
+      switch(
+        val,
+        # THE CASES BY VACCINATION STATUS CHART ARE UPDATED WEEKLY ON MONDAYS (EXCLUDING HOLIDAYS). THE DATE SHOWN IS THE LAST DATE PRIOR TO REPORTING (i.e. SUNDAY). DETAILED DEFINITIONS AT: https://covid-19-data-dashboard.service.yukon.ca/
+        "cases" = {
+          switch(
+            fmt,
+            "prov_ts" = {
+              ds$features$attributes %>%
+                dplyr::transmute(
+                  date = lubridate::date(
+                    lubridate::with_tz(as.POSIXct(.data$EPI_WEEK_DATE / 1000, origin = "1970-01-01"), tz = "UTC")),
+                  date = date - 7,
+                  value = .data$TOTAL_CASES) %>%
+                helper_ts(loc = "prov", val, prov, convert_to_cum = FALSE)
+            },
+            e_fmt()
+          )
+        },
+        e_val()
+      )
+    },
+    "af6ea226-0325-4800-bac2-9239dd507b49" = {
+      switch(
+        val,
+        # THE CASES BY VACCINATION STATUS CHART ARE UPDATED WEEKLY ON MONDAYS (EXCLUDING HOLIDAYS). THE DATE SHOWN IS THE LAST DATE PRIOR TO REPORTING (i.e. SUNDAY). DETAILED DEFINITIONS AT: https://covid-19-data-dashboard.service.yukon.ca/
+        "cases" = {
+          switch(
+            fmt,
+            "prov_ts" = {
+              ds$features$attributes %>%
+                dplyr::transmute(
+                  date = lubridate::date(
+                    lubridate::with_tz(as.POSIXct(.data$EPI_WEEK_DATE / 1000, origin = "1970-01-01"), tz = "UTC")),
+                  date = date - 7,
+                  value = .data$TOTAL_CASES) %>%
+                helper_ts(loc = "prov", val, prov, convert_to_cum = FALSE)
+            },
+            e_fmt()
+          )
+        },
+        e_val()
+      )
+    },
     e_uuid()
   )
 }

--- a/R/yt.R
+++ b/R/yt.R
@@ -379,8 +379,8 @@ process_yt <- function(uuid, val, fmt, ds,
               ds$features$attributes %>%
                 dplyr::transmute(
                   date = lubridate::date(
-                    lubridate::with_tz(as.POSIXct(.data$EPI_WEEK_DATE / 1000, origin = "1970-01-01"), tz = "UTC")),
-                  date = date - 7,
+                    lubridate::with_tz(as.POSIXct(.data$EPI_WEEK_DATE / 1000, origin = "1970-01-01"), tz = "UTC"))-7,
+                  # Subtract one week in the above date-time conversion because EPI_WEEK_DATE reports the Sunday of the week in which cases were reported (i.e. cases are typically reported on the Monday after a given week but EPI_WEEK_DATE reports the next Sunday which is the end of the week in which cases were reported)
                   value = .data$TOTAL_CASES) %>%
                 helper_ts(loc = "prov", val, prov, convert_to_cum = FALSE)
             },


### PR DESCRIPTION
Addition of code to process AB, BC, NL, YT time series data.
Note: YT reports weekly data in a epi-week date formats. One week needed to be subtracted from the date variable to indicate the last date of data collection (i.e. data collected up to Sunday March 6 but reported on Monday March 7) rather than the last day of the week of data reporting (i.e. Sunday March 13).